### PR TITLE
Point to forks of swiftformat and swiftlint linux compatible artifactbundles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         ]),
       dependencies: [
         "AirbnbSwiftFormatTool",
-        "SwiftFormat",
-        "SwiftLintBinary",
+        "swiftformat",
+        "swiftlint",
       ]),
 
     .executableTarget(
@@ -37,12 +37,11 @@ let package = Package(
       ]),
 
     .binaryTarget(
-      name: "SwiftFormat",
-      url: "https://github.com/calda/SwiftFormat/releases/download/0.51-beta-3/SwiftFormat.artifactbundle.zip",
-      checksum: "4b0516d911258b55c3960949f4a516a246f35a1dc7647a6440c66e1f1fe1a32e"),
-
+      name: "swiftformat",
+      url: "https://github.com/doozMen/SwiftFormat/releases/download/0.51-beta4/swiftformat.artifactbundle.zip",
+      checksum: "325a01367ba959f9ba1eaf0f8e8b43a224a81ea8c55cfd0f005afd4e00a70c1b"),
     .binaryTarget(
-      name: "SwiftLintBinary",
+      name: "swiftlint",
       url: "https://github.com/doozMen/SwiftLint/releases/download/0.49.1/swiftlint.artifactbundle.zip",
-      checksum: "71c3b309e7a52fece109b5ab0d81f826a5e5bc0202035e6228d5956f24acdb49"),
+      checksum: "aefc21b6d9311ed3e29042ae22c815506d8b0c7c2a8cfe9995ae6e813db4b5e4"),
   ])

--- a/Package.swift
+++ b/Package.swift
@@ -43,5 +43,5 @@ let package = Package(
     .binaryTarget(
       name: "swiftlint",
       url: "https://github.com/doozMen/SwiftLint/releases/download/0.49.1/swiftlint.artifactbundle.zip",
-      checksum: "aefc21b6d9311ed3e29042ae22c815506d8b0c7c2a8cfe9995ae6e813db4b5e4"),
+      checksum: "5a4a63a2fa22020da781c459336e17fefdb27baf54ab93fc76e340f5484b8483"),
   ])

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     .binaryTarget(
       name: "swiftformat",
       url: "https://github.com/doozMen/SwiftFormat/releases/download/0.51-beta4/swiftformat.artifactbundle.zip",
-      checksum: "325a01367ba959f9ba1eaf0f8e8b43a224a81ea8c55cfd0f005afd4e00a70c1b"),
+      checksum: "f11b4e78fae995a211df87f0bf89f00bbccfecae42074d20e2b8e15b296200dd"),
     .binaryTarget(
       name: "swiftlint",
       url: "https://github.com/doozMen/SwiftLint/releases/download/0.49.1/swiftlint.artifactbundle.zip",

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     .binaryTarget(
       name: "swiftformat",
       url: "https://github.com/doozMen/SwiftFormat/releases/download/0.51-beta4/swiftformat.artifactbundle.zip",
-      checksum: "f11b4e78fae995a211df87f0bf89f00bbccfecae42074d20e2b8e15b296200dd"),
+      checksum: "0255d8db7a8955467e7e548f9fbeda489fe0d5084d59d5144e662eb9e0bdc3d4"),
     .binaryTarget(
       name: "swiftlint",
       url: "https://github.com/doozMen/SwiftLint/releases/download/0.49.1/swiftlint.artifactbundle.zip",

--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,6 @@ let package = Package(
 
     .binaryTarget(
       name: "SwiftLintBinary",
-      url: "https://github.com/realm/SwiftLint/releases/download/0.48.0/SwiftLintBinary-macos.artifactbundle.zip",
-      checksum: "9c255e797260054296f9e4e4cd7e1339a15093d75f7c4227b9568d63edddba50"),
+      url: "https://github.com/doozMen/SwiftLint/releases/download/0.49.1/swiftlint.artifactbundle.zip",
+      checksum: "71c3b309e7a52fece109b5ab0d81f826a5e5bc0202035e6228d5956f24acdb49"),
   ])


### PR DESCRIPTION
See explanation in the releases

- [swiftformat from calda - 0.51-beta4](https://github.com/doozMen/SwiftFormat/releases/tag/0.51-beta4)
- [swiftlint from 0.49.1](https://github.com/doozMen/SwiftLint/releases/tag/0.49.1)